### PR TITLE
Added sorting of eigs in function 'principal_stresses'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+* Function 'principal stresses' : adding sorting of the resulting eigenvectors + eigenvalues
 
 ### Removed
 

--- a/src/compas_fea/utilities/functions.py
+++ b/src/compas_fea/utilities/functions.py
@@ -616,17 +616,12 @@ def principal_stresses(data):
             stress_matrix = np.array([(stress_vector[0], stress_vector[1]),
                                       (stress_vector[1], stress_vector[2])])
             w_sp, v_sp = np.linalg.eig(stress_matrix)
-
-            # find larger/smaller value (numpy does not sort the eigenvectors/eigenvalues by magnitude : https://numpy.org/doc/stable/reference/generated/numpy.linalg.eig.html)
-            sorted_magn_indices = []
-            if abs(w_sp[0]) > abs(w_sp[1]):
-                sorted_magn_indices = [0, 1]
-            else:
-                sorted_magn_indices = [1, 0]
-
+            # sort by larger to smaller eigenvalue
+            idx = w_sp.argsort()[::-1]
+            w_sp = w_sp[idx]
+            v_sp = v_sp[:, idx]
+            # populate results
             for v, k in enumerate(stype):
-                ii = sorted_magn_indices[v]
-                spr[sp][k][c] += w_sp[ii]
-                e[sp][k][:, c] += v_sp[:, ii]
-
+                spr[sp][k][c] += w_sp[v]
+                e[sp][k][:, c] += v_sp[:, v]
     return spr, e

--- a/src/compas_fea/utilities/functions.py
+++ b/src/compas_fea/utilities/functions.py
@@ -616,8 +616,17 @@ def principal_stresses(data):
             stress_matrix = np.array([(stress_vector[0], stress_vector[1]),
                                       (stress_vector[1], stress_vector[2])])
             w_sp, v_sp = np.linalg.eig(stress_matrix)
+
+            # find larger/smaller value (numpy does not sort the eigenvectors/eigenvalues by magnitude : https://numpy.org/doc/stable/reference/generated/numpy.linalg.eig.html) 
+            sorted_magn_indices = []
+            if abs(w_sp[0]) > abs(w_sp[1]):
+                sorted_magn_indices = [0, 1]
+            else:
+                sorted_magn_indices = [1, 0]
+
             for v, k in enumerate(stype):
-                spr[sp][k][c] += w_sp[v]
-                e[sp][k][:, c] += v_sp[:, v]
+                ii = sorted_magn_indices[v]
+                spr[sp][k][c] += w_sp[ii]
+                e[sp][k][:, c] += v_sp[:, ii]
 
     return spr, e

--- a/src/compas_fea/utilities/functions.py
+++ b/src/compas_fea/utilities/functions.py
@@ -617,7 +617,7 @@ def principal_stresses(data):
                                       (stress_vector[1], stress_vector[2])])
             w_sp, v_sp = np.linalg.eig(stress_matrix)
 
-            # find larger/smaller value (numpy does not sort the eigenvectors/eigenvalues by magnitude : https://numpy.org/doc/stable/reference/generated/numpy.linalg.eig.html) 
+            # find larger/smaller value (numpy does not sort the eigenvectors/eigenvalues by magnitude : https://numpy.org/doc/stable/reference/generated/numpy.linalg.eig.html)
             sorted_magn_indices = []
             if abs(w_sp[0]) > abs(w_sp[1]):
                 sorted_magn_indices = [0, 1]


### PR DESCRIPTION
The numpy linalg.eigs() function does not sort the eigenvectors/eigenvalues by magnitude. I added a small check so that the min/max fields are filled in by the larges/smallest eigenvector+eigenvalue respectively 